### PR TITLE
Implement env var handling for RemoteCertificateNameMismatch

### DIFF
--- a/UsenetSharp/Clients/UsenetClient.ConnectAsync.cs
+++ b/UsenetSharp/Clients/UsenetClient.ConnectAsync.cs
@@ -21,10 +21,36 @@ public partial class UsenetClient
 
             if (useSsl)
             {
-                var sslStream = new SslStream(_stream, false);
+                var sslStream = new SslStream(_stream, false, (sender, certificate, chain, sslPolicyErrors) =>
+                {
+                    // ENV vars control SSL behavior
+                    var ignoreNameMismatch = Environment.GetEnvironmentVariable("NNTP_TLS_IGNORE_NAME_MISMATCH");
+                    var ignoreDomains = Environment.GetEnvironmentVariable("NNTP_TLS_IGNORE_CERT_DOMAINS");
+
+                    // Ignore server name mismatch globally if requested
+                    if (!string.IsNullOrWhiteSpace(ignoreNameMismatch) &&
+                        (ignoreNameMismatch == "1" || ignoreNameMismatch.Equals("true", StringComparison.OrdinalIgnoreCase)))
+                    {
+                        sslPolicyErrors &= ~SslPolicyErrors.RemoteCertificateNameMismatch;
+                    }
+
+                    // Ignore cert errors for specific domains
+                    if (!string.IsNullOrWhiteSpace(ignoreDomains))
+                    {
+                        var domains = ignoreDomains.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                        if (domains.Contains(host, StringComparer.OrdinalIgnoreCase))
+                        {
+                            return true; // bypass all TLS errors for this host
+                        }
+                    }
+
+                    return sslPolicyErrors == SslPolicyErrors.None;
+                });
+
                 await sslStream.AuthenticateAsClientAsync(host, null,
                     System.Security.Authentication.SslProtocols.Tls12 |
                     System.Security.Authentication.SslProtocols.Tls13, true);
+
                 _stream = sslStream;
             }
 
@@ -39,7 +65,9 @@ public partial class UsenetClient
             // NNTP servers typically respond with "200" or "201" for successful connection
             if (responseCode != (int)UsenetResponseType.ServerReadyPostingAllowed &&
                 responseCode != (int)UsenetResponseType.ServerReadyNoPostingAllowed)
+            {
                 throw new UsenetConnectionException(response!) { ResponseCode = responseCode };
+            }
         }
         finally
         {


### PR DESCRIPTION
Adds handling for two ENV vars to ignore RemoteCertificateNameMismatch on an SSL connection. Can either be set globally for all, or for specific domains.