### PR TITLE
Add pipelined STAT existence checks (StatPipelinedAsync)

### DIFF
--- a/UsenetSharp/Clients/IUsenetClient.cs
+++ b/UsenetSharp/Clients/IUsenetClient.cs
@@ -13,6 +13,9 @@ public interface IUsenetClient
     Task<UsenetStatResponse> StatAsync(
         SegmentId segmentId, CancellationToken cancellationToken);
 
+    Task<IReadOnlyList<UsenetStatResponse>> StatPipelinedAsync(
+        IReadOnlyList<SegmentId> segmentIds, CancellationToken cancellationToken);
+
     Task<UsenetHeadResponse> HeadAsync(
         SegmentId segmentId, CancellationToken cancellationToken);
 

--- a/UsenetSharp/Clients/UsenetClient.ConnectAsync.cs
+++ b/UsenetSharp/Clients/UsenetClient.ConnectAsync.cs
@@ -16,6 +16,10 @@ public partial class UsenetClient
         try
         {
             _tcpClient = new TcpClient();
+            // Disable Nagle's algorithm. NNTP commands are small and latency-sensitive; with Nagle
+            // on, pipelined commands written back-to-back stall waiting for delayed ACKs, which makes
+            // pipelined STAT batches dramatically slower than sending each command immediately.
+            _tcpClient.NoDelay = true;
             await _tcpClient.ConnectAsync(host, port, cancellationToken);
             _stream = _tcpClient.GetStream();
 

--- a/UsenetSharp/Clients/UsenetClient.StatPipelinedAsync.cs
+++ b/UsenetSharp/Clients/UsenetClient.StatPipelinedAsync.cs
@@ -1,0 +1,131 @@
+using System.Runtime.ExceptionServices;
+using System.Text;
+using UsenetSharp.Exceptions;
+using UsenetSharp.Models;
+
+namespace UsenetSharp.Clients;
+
+public partial class UsenetClient
+{
+    /// <summary>
+    /// Performs a STAT existence check for many segments using NNTP command pipelining (RFC 3977 §3.5).
+    ///
+    /// All STAT commands in the batch are written back-to-back and flushed once, then the responses
+    /// are read in order. Because each STAT reply is a single line and replies are returned in the
+    /// same order the commands were sent, this collapses what would be one network round-trip per
+    /// segment into a single round-trip for the whole batch.
+    ///
+    /// The entire batch runs as one logical operation while holding the per-connection command lock,
+    /// so it composes with the rest of the client exactly like a single command. If anything goes
+    /// wrong mid-batch the underlying stream is left in an indeterminate state (partially written
+    /// commands or unread responses), so the connection is marked unhealthy and must be discarded by
+    /// the caller — never reused.
+    /// </summary>
+    /// <param name="segmentIds">The segments to STAT, checked in order.</param>
+    /// <param name="cancellationToken">Cancels waiting for the connection's command lock.</param>
+    /// <returns>One <see cref="UsenetStatResponse"/> per input segment, in the same order.</returns>
+    public async Task<IReadOnlyList<UsenetStatResponse>> StatPipelinedAsync
+    (
+        IReadOnlyList<SegmentId> segmentIds,
+        CancellationToken cancellationToken
+    )
+    {
+        if (segmentIds.Count == 0)
+            return [];
+
+        await _commandLock.WaitAsync(cancellationToken);
+        try
+        {
+            ThrowIfUnhealthy();
+            ThrowIfNotConnected();
+
+            // A single idle-based deadline for the whole batch. One timer per command would create a
+            // storm of timers under many concurrent connections, and a fixed total-batch budget would
+            // false-fire when a batch legitimately queues behind other connections' work. Instead we
+            // bound the gap between consecutive replies and re-arm on each one: a busy-but-alive
+            // connection keeps resetting it, while a genuinely stalled connection still trips it.
+            var idleTimeout = TimeSpan.FromSeconds(20);
+            using var batchCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
+            batchCts.CancelAfter(idleTimeout);
+            var token = batchCts.Token;
+
+            try
+            {
+                // Phase 1 -- write the whole batch in one direct stream write. Going through the
+                // AutoFlush StreamWriter would fragment a large batch into several small TLS records
+                // and throttle the pipeline; one buffer write (with TCP_NODELAY) puts it on the wire
+                // as a single blast so the server pipelines it. The writer holds no buffered data, so
+                // bypassing it stays in sync; Latin1 matches its encoding (one byte per char).
+                var payload = new StringBuilder(segmentIds.Count * 32);
+                foreach (var segmentId in segmentIds)
+                    payload.Append("STAT <").Append((string)segmentId).Append(">\r\n");
+                var payloadBytes = Encoding.Latin1.GetBytes(payload.ToString());
+                await _stream!.WriteAsync(payloadBytes, token).ConfigureAwait(false);
+                await _stream!.FlushAsync(token).ConfigureAwait(false);
+
+                // Phase 2 -- read one response line per command, in order.
+                var responses = new UsenetStatResponse[segmentIds.Count];
+                for (var i = 0; i < segmentIds.Count; i++)
+                {
+                    var response = await _reader!.ReadLineAsync(token).ConfigureAwait(false);
+                    // Re-arm the idle deadline: progress was made, so the clock restarts for the
+                    // next reply rather than counting down against the whole batch.
+                    batchCts.CancelAfter(idleTimeout);
+                    if (response is null)
+                        throw new UsenetProtocolException(
+                            "Connection closed while reading pipelined STAT responses.");
+
+                    var responseCode = ParseResponseCode(response);
+                    var articleExists = responseCode == (int)UsenetResponseType.ArticleExists;
+
+                    // Desync guard: a 223 reply echoes the message-id ("223 0 <message-id>").
+                    // If the echoed id does not match the command we sent at this position then the
+                    // response stream is misaligned and every later mapping would be wrong, so we
+                    // abort the whole batch rather than return bogus existence results.
+                    if (articleExists && !ResponseEchoesSegmentId(response, segmentIds[i]))
+                        throw new UsenetProtocolException(
+                            "Pipelined STAT responses are out of order; aborting batch.");
+
+                    responses[i] = new UsenetStatResponse
+                    {
+                        ResponseCode = responseCode,
+                        ResponseMessage = response,
+                        ArticleExists = articleExists,
+                    };
+                }
+
+                return responses;
+            }
+            catch (Exception e)
+            {
+                // Translate our own batch-timeout into a TimeoutException (a real caller cancel or a
+                // disconnect via _cts propagates as-is).
+                if (e is OperationCanceledException && batchCts.IsCancellationRequested
+                    && !_cts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                    e = new TimeoutException("Timeout during pipelined STAT batch.");
+
+                // The stream position is now indeterminate (unwritten commands and/or unread
+                // pipelined responses). Poison the connection so it is never silently reused with a
+                // desynced stream; the caller is expected to discard it.
+                lock (this)
+                {
+                    _backgroundException ??= ExceptionDispatchInfo.Capture(e);
+                }
+
+                throw e;
+            }
+        }
+        finally
+        {
+            _commandLock.Release();
+        }
+    }
+
+    private static bool ResponseEchoesSegmentId(string response, SegmentId segmentId)
+    {
+        var id = segmentId.Value;
+        // Nothing to verify against (empty id) -- trust the in-order guarantee.
+        if (id.IsEmpty) return true;
+        return response.AsSpan().IndexOf(id, StringComparison.Ordinal) >= 0;
+    }
+}

--- a/UsenetSharpTest/Clients/UsenetClient.StatPipelinedAsyncTests.cs
+++ b/UsenetSharpTest/Clients/UsenetClient.StatPipelinedAsyncTests.cs
@@ -1,0 +1,114 @@
+using UsenetSharp.Clients;
+using UsenetSharp.Models;
+
+namespace UsenetSharpTest.Clients;
+
+public class StatPipelinedAsyncTests
+{
+    private static readonly string[] ValidSegmentIds = new[]
+    {
+        "8mthBMhpfyOJFM7OPe2RsZhm@CAtZlPkA1OiI.WLo",
+        "439e9msqibLI2Ckyt7z6EMUY@iLqyzimBg7ac.t2n",
+        "RdmCrBrzTPnTiYj7ze5Gwyt6@mfdz3EInI86g.bfV",
+        "njX6awmG5Rl0lZbBbfll8WtA@M6zC3hmaiMoK.w5x",
+        "vAOEczfxpsXMjg0bUPUGO7Bb@KDqE994Bw3O0.BG5"
+    };
+
+    [Test]
+    public async Task StatPipelinedAsync_WithEmptyBatch_ReturnsEmptyList()
+    {
+        // Arrange
+        var client = new UsenetClient();
+
+        // Act
+        var results = await client.StatPipelinedAsync([], CancellationToken.None);
+
+        // Assert -- empty batch short-circuits before touching the connection
+        Assert.That(results, Is.Empty);
+    }
+
+    [Test]
+    public async Task StatPipelinedAsync_WithValidSegmentIds_ReturnsExistsInOrder()
+    {
+        // Arrange
+        var client = new UsenetClient();
+        var cancellationToken = CancellationToken.None;
+        await client.ConnectAsync(Credentials.Host, 563, true, cancellationToken);
+        await client.AuthenticateAsync(Credentials.Username, Credentials.Password, cancellationToken);
+
+        var batch = ValidSegmentIds.Select(x => (SegmentId)x).ToArray();
+
+        // Act
+        var results = await client.StatPipelinedAsync(batch, cancellationToken);
+
+        // Assert -- one response per segment, all present, returned in request order
+        Assert.That(results, Has.Count.EqualTo(batch.Length));
+        for (var i = 0; i < results.Count; i++)
+        {
+            Assert.That(results[i].ArticleExists, Is.True, $"Article should exist for {ValidSegmentIds[i]}");
+            Assert.That(results[i].ResponseCode, Is.EqualTo(223));
+            Assert.That(results[i].ResponseType, Is.EqualTo(UsenetResponseType.ArticleExists));
+            Assert.That(results[i].ResponseMessage, Does.Contain(ValidSegmentIds[i]),
+                "Each 223 response should echo the message-id it corresponds to");
+        }
+    }
+
+    [Test]
+    public async Task StatPipelinedAsync_WithMixedBatch_MapsEachResponseToItsPosition()
+    {
+        // Arrange
+        var client = new UsenetClient();
+        var cancellationToken = CancellationToken.None;
+        await client.ConnectAsync(Credentials.Host, 563, true, cancellationToken);
+        await client.AuthenticateAsync(Credentials.Username, Credentials.Password, cancellationToken);
+
+        // Interleave a known-missing id between known-good ids to prove per-position mapping.
+        var batch = new SegmentId[]
+        {
+            ValidSegmentIds[0],
+            "definitely-missing@nonexistent.invalid",
+            ValidSegmentIds[1],
+        };
+
+        // Act
+        var results = await client.StatPipelinedAsync(batch, cancellationToken);
+
+        // Assert
+        Assert.That(results, Has.Count.EqualTo(3));
+        Assert.That(results[0].ArticleExists, Is.True);
+        Assert.That(results[0].ResponseCode, Is.EqualTo(223));
+
+        Assert.That(results[1].ArticleExists, Is.False);
+        Assert.That(results[1].ResponseCode, Is.EqualTo(430));
+
+        Assert.That(results[2].ArticleExists, Is.True);
+        Assert.That(results[2].ResponseCode, Is.EqualTo(223));
+    }
+
+    [Test]
+    public async Task StatPipelinedAsync_MatchesSequentialStatResults()
+    {
+        // Arrange
+        var client = new UsenetClient();
+        var cancellationToken = CancellationToken.None;
+        await client.ConnectAsync(Credentials.Host, 563, true, cancellationToken);
+        await client.AuthenticateAsync(Credentials.Username, Credentials.Password, cancellationToken);
+
+        var batch = ValidSegmentIds.Select(x => (SegmentId)x).ToArray();
+
+        // Act -- pipelined batch versus the proven one-at-a-time path
+        var pipelined = await client.StatPipelinedAsync(batch, cancellationToken);
+
+        var sequential = new List<UsenetStatResponse>();
+        foreach (var id in batch)
+            sequential.Add(await client.StatAsync(id, cancellationToken));
+
+        // Assert -- pipelining must not change the observed result for any segment
+        Assert.That(pipelined, Has.Count.EqualTo(sequential.Count));
+        for (var i = 0; i < pipelined.Count; i++)
+        {
+            Assert.That(pipelined[i].ResponseCode, Is.EqualTo(sequential[i].ResponseCode));
+            Assert.That(pipelined[i].ArticleExists, Is.EqualTo(sequential[i].ArticleExists));
+        }
+    }
+}


### PR DESCRIPTION
## What
Adds `UsenetClient.StatPipelinedAsync(IReadOnlyList<SegmentId>, CancellationToken)` and the matching `IUsenetClient` member — a STAT existence check for many segments using NNTP command pipelining (RFC 3977 §3.5).

## Why
STAT replies are single-line and return in order, so a batch can be written back-to-back and read in one pass — collapsing one network round-trip per segment into a single round-trip per batch. On higher-latency links this is a large speedup for bulk existence checks (e.g. article-health checks).

## How
- Writes the whole batch in one direct stream write (bypassing the `AutoFlush` `StreamWriter`, which would fragment it into several small TLS records and throttle the pipeline), with `TCP_NODELAY` so it goes on the wire as a single blast.
- Reads one single-line reply per command, in order, under an **idle-based** per-batch deadline re-armed on each reply: a busy-but-alive connection won't false-time-out under load, while a genuinely stalled one still trips.
- **Desync guard:** a `223` reply must echo the requested message-id, else the batch aborts rather than returning misaligned results.
- On any mid-batch failure the connection is **poisoned** (left indeterminate) and must be discarded by the caller, never silently reused.

## Tests
`UsenetClient.StatPipelinedAsyncTests`: empty-batch short-circuit, all-present, interleaved known-missing id (per-position mapping), and equivalence with one-at-a-time `StatAsync`. (Integration tests — fill `Credentials.cs` to run, like the existing suite.)

## Notes
Adds a member to `IUsenetClient` (new API surface) — worth a version bump on release so downstream (nzbdav) can depend on it.
